### PR TITLE
Instance table names

### DIFF
--- a/lib/commutator/model/table_configuration.rb
+++ b/lib/commutator/model/table_configuration.rb
@@ -16,8 +16,17 @@ module Commutator
         send(primary_key_range_name) if primary_key_range_name.present?
       end
 
-      def table_name
-        self.class.table_name
+      included do
+        class_attribute :table_name
+
+        class << self
+          prepend(Module.new do
+            def table_name(*args)
+              return super if args.size == 0
+              send("table_name=", *args)
+            end
+          end)
+        end
       end
 
       # :nodoc:

--- a/spec/commutator/model/table_configuration_spec.rb
+++ b/spec/commutator/model/table_configuration_spec.rb
@@ -21,6 +21,14 @@ RSpec.describe Commutator::Model::TableConfiguration do
     end
   end
 
+  describe ".table_name" do
+    it "takes an argument in order to set the value" do
+      expect(test_class.table_name).to eq 'test_table'
+      test_class.table_name 'nonsense'
+      expect(test_class.table_name).to eq 'nonsense'
+    end
+  end
+
   describe '#table_name' do
     it 'picks up the class level table_name value' do
       expect(instance.table_name).to eq(test_class.table_name)

--- a/spec/commutator/model/table_configuration_spec.rb
+++ b/spec/commutator/model/table_configuration_spec.rb
@@ -22,8 +22,16 @@ RSpec.describe Commutator::Model::TableConfiguration do
   end
 
   describe '#table_name' do
-    it 'delegates to .table_name' do
+    it 'picks up the class level table_name value' do
       expect(instance.table_name).to eq(test_class.table_name)
+    end
+  end
+
+  describe '#table_name=' do
+    it 'sets the instance table name to a value that differs from the class-level value' do
+      instance.table_name = 'new value'
+      expect(instance.table_name).to eq 'new value'
+      expect(instance.class.table_name).not_to eq(instance.table_name)
     end
   end
 


### PR DESCRIPTION
Allow users to set table names at the instance level to allow flexibility in defining/using models.